### PR TITLE
fix(common): edge cases around use of ObjectId as id

### DIFF
--- a/src/common/mapObject.ts
+++ b/src/common/mapObject.ts
@@ -4,7 +4,6 @@ import { DocumentBase } from '../types'
 type Param<T> = T | null | undefined
 
 export default function <T extends DocumentBase>(doc: Param<T>) {
-
 	if (!doc) {
 		return null
 	}
@@ -14,10 +13,12 @@ export default function <T extends DocumentBase>(doc: Param<T>) {
 	const _id: ObjectId = obj['_id']
 
 	if (_id) {
-		if (_id instanceof ObjectId) {
+		if (
+			Reflect.has(_id, '_bsontype') &&
+			_id._bsontype.toLocaleLowerCase() === 'objectid'
+		) {
 			obj.id = _id.toHexString()
-		}
-		else {
+		} else {
 			obj.id = _id
 		}
 

--- a/src/common/mapObject.ts
+++ b/src/common/mapObject.ts
@@ -15,11 +15,11 @@ export default function <T extends DocumentBase>(doc: Param<T>) {
 	if (_id) {
 		if (
 			Reflect.has(_id, '_bsontype') &&
-			_id._bsontype.toLocaleLowerCase() === 'objectid'
+			(_id as any)._bsontype.toLocaleLowerCase() === 'objectid'
 		) {
 			obj.id = _id.toHexString()
 		} else {
-			obj.id = _id
+			obj.id = _id as any
 		}
 
 		delete obj['_id']

--- a/src/common/transformIdFilter.ts
+++ b/src/common/transformIdFilter.ts
@@ -10,6 +10,14 @@ export default function <T extends DocumentBase>(filter: FilterQuery<T>) {
 			const filterAny = filter as any
 			filterAny['_id'] = new ObjectId(filter.id)
 		}
+		// if id is already an objectId
+		else if (
+			Reflect.has(filter.id, '_bsontype') &&
+			filter.id._bsontype === 'ObjectID'
+		) {
+			const filterAny = filter as any
+			filterAny['_id'] = filter.id
+		}
 		// if $in is used
 		else if (filter.id['$in'] && Array.isArray(filter.id['$in'])) {
 			const ids = filter.id['$in']

--- a/src/common/transformIdFilter.ts
+++ b/src/common/transformIdFilter.ts
@@ -12,8 +12,8 @@ export default function <T extends DocumentBase>(filter: FilterQuery<T>) {
 		}
 		// if id is already an objectId
 		else if (
-			Reflect.has(filter.id, '_bsontype') &&
-			filter.id._bsontype === 'ObjectID'
+			Reflect.has(filter.id as object, '_bsontype') &&
+			(filter.id as any)._bsontype === 'ObjectID'
 		) {
 			const filterAny = filter as any
 			filterAny['_id'] = filter.id


### PR DESCRIPTION
It seems that somewhere between `mongodb@3.5.9` from `mongodb@3.5.5` detecting an `ObjectId` using `instanceof ObjectId` no longer succeeds, causing mango to return the `id` prop as an `ObjectId` type, instead of a `string`.

This PR provides alternate logic to map the return `id` to a string by detecting the presence of the `_bsontype` prop, and checking that its value is `ObjectID`. 

Also fixes an edge case where IDs used for filters are actually BSON ObjectIDs, not strings

This became an issue when updating to `mongodb@3.5.9` from `mongodb@3.5.5`